### PR TITLE
LWT for 2nd dropped connection

### DIFF
--- a/mqtt.js
+++ b/mqtt.js
@@ -358,7 +358,8 @@ function onConnectionLost(responseObject) {
         console.log(responseObject.errorMessage);
     } // reconnect
     mqttClient.connect({
-        onSuccess: onConnect
+        onSuccess: onConnect,
+        willMessage: lwt // ensure 2nd disconnect will not leave head in scene
     });
 }
 


### PR DESCRIPTION
- If the broker connection was lost, we also need to use LWT to ensure we do not leave a head in the scene.