### PR TITLE
Add exception for /dev/folders

### DIFF
--- a/events.js
+++ b/events.js
@@ -7,6 +7,9 @@
 // Handles hostname.com/?scene=foo, hostname.com/foo, and hostname.com/namespace/foo
 const getSceneName = () => {
     let path = window.location.pathname.substring(1);
+    if (defaults.supportDevFolders) {
+        path=path.replace(path.match(/dev\/([^\/]+)\/?/g)[0], "");
+    }	
     if (path === '' || path === 'index.html') {
         return getUrlParam('scene', defaults.scenenameParam);
     }


### PR DESCRIPTION
Adding exception to URL path processing to support `/dev/npereira`,` /dev/ivan`, /`dev/shiny-new-feature`... folders, **but only if defaults.supportDevFolders==true**.