### PR TITLE
Emit all clientEvents on user id object topics, not targets

### DIFF
--- a/src/components/arena-vive.js
+++ b/src/components/arena-vive.js
@@ -17,6 +17,7 @@ function eventAction(evt, eventName, myThis) {
 
     // publish to MQTT
     const objName = myThis.id + '_' + ARENA.idTag;
+    // publishing events attached to user id objects allows sculpting security
     ARENA.Mqtt.publish(ARENA.outputTopic + objName, {
         object_id: objName,
         action: 'clientEvent',

--- a/src/components/click-listener.js
+++ b/src/components/click-listener.js
@@ -31,7 +31,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
-                    ARENA.Mqtt.publish(ARENA.outputTopic + this.id, thisMsg);
+                    ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
             }
         });
@@ -56,7 +56,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
-                    ARENA.Mqtt.publish(ARENA.outputTopic + this.id, thisMsg);
+                    ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
             }
         });
@@ -81,7 +81,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
-                    ARENA.Mqtt.publish(ARENA.outputTopic + this.id, thisMsg);
+                    ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
                 window.lastMouseTarget = this.id;
             }
@@ -107,7 +107,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
-                    ARENA.Mqtt.publish(ARENA.outputTopic + this.id, thisMsg);
+                    ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
                 window.lastMouseTarget = undefined;
             }

--- a/src/components/click-listener.js
+++ b/src/components/click-listener.js
@@ -31,6 +31,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
+                    // publishing events attached to user id objects allows sculpting security
                     ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
             }
@@ -56,6 +57,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
+                    // publishing events attached to user id objects allows sculpting security
                     ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
             }
@@ -81,6 +83,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
+                    // publishing events attached to user id objects allows sculpting security
                     ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
                 window.lastMouseTarget = this.id;
@@ -107,6 +110,7 @@ AFRAME.registerComponent('click-listener', {
                     },
                 };
                 if (!self.el.getAttribute('goto-url')) {
+                    // publishing events attached to user id objects allows sculpting security
                     ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
                 }
                 window.lastMouseTarget = undefined;

--- a/src/components/collision-listener.js
+++ b/src/components/collision-listener.js
@@ -34,7 +34,7 @@ AFRAME.registerComponent('collision-listener', {
                     source: collider,
                 },
             };
-            ARENA.Mqtt.publish(ARENA.outputTopic + this.id, thisMsg);
+            ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
         });
     },
 });

--- a/src/components/collision-listener.js
+++ b/src/components/collision-listener.js
@@ -34,6 +34,7 @@ AFRAME.registerComponent('collision-listener', {
                     source: collider,
                 },
             };
+            // publishing events attached to user id objects allows sculpting security
             ARENA.Mqtt.publish(ARENA.outputTopic + ARENA.camName, thisMsg);
         });
     },


### PR DESCRIPTION
- Allows enforcing security model that anonymous users can only publish to user id object topics like `camera_8888_Mike`.