### PR TITLE
Add navmesh constraint support for movements

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         <a-entity position="0 0 0" id="cameraRig">
           <a-entity position="0 0 0" id="cameraSpinner" name="PerspectiveCamera" tag="MainCamera">
             <!-- this camera can 'fly': z axis follows pitch of head direction -->
-            <a-camera id="my-camera" far="10000" near="0.1" wasd-controls="fly: false; acceleration: 30" look-controls="reverseMouseDrag: true" look-controls-arrow mouse-cursor press-and-move network-latency gesture-detector>
+            <a-camera id="my-camera" far="10000" near="0.1" wasd-controls="fly: false; acceleration: 30; constrainToNavMesh:true " look-controls="reverseMouseDrag: true" look-controls-arrow mouse-cursor press-and-move network-latency gesture-detector>
               <a-entity id="mouse-cursor" cursor="rayOrigin: mouse" raycaster="objects:[click-listener]"></a-entity>
             </a-camera>
           </a-entity>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,8 @@
         <a-entity position="0 0 0" id="cameraRig">
           <a-entity position="0 0 0" id="cameraSpinner" name="PerspectiveCamera" tag="MainCamera">
             <!-- this camera can 'fly': z axis follows pitch of head direction -->
-            <a-camera id="my-camera" far="10000" near="0.1" wasd-controls="fly: false; acceleration: 30; constrainToNavMesh:true " look-controls="reverseMouseDrag: true" look-controls-arrow mouse-cursor press-and-move network-latency gesture-detector>
+            <a-camera id="my-camera" far="10000" near="0.1" wasd-controls="fly: false; acceleration: 30; constrainToNavMesh:true" look-controls="reverseMouseDrag: true"
+                      look-controls-arrow mouse-cursor press-and-move="constrainToNavMesh:true" network-latency gesture-detector>
               <a-entity id="mouse-cursor" cursor="rayOrigin: mouse" raycaster="objects:[click-listener]"></a-entity>
             </a-camera>
           </a-entity>

--- a/src/aframe-mods/wasd-speed-controls.js
+++ b/src/aframe-mods/wasd-speed-controls.js
@@ -51,7 +51,7 @@ AFRAME.components['wasd-controls'].Component.prototype.tick = function(time, del
         return;
     }
 
-    if (data.constrainToNavMesh) {
+    if (data.constrainToNavMesh && !this.data.fly) {
         if (velocity.lengthSq() < EPS) return;
 
         start.copy(el.object3D.position);

--- a/src/aframe-mods/wasd-speed-controls.js
+++ b/src/aframe-mods/wasd-speed-controls.js
@@ -50,14 +50,13 @@ AFRAME.components['wasd-controls'].Component.prototype.tick = function(time, del
     if (!velocity[data.adAxis] && !velocity[data.wsAxis]) {
         return;
     }
-
-    if (data.constrainToNavMesh && !this.data.fly) {
+    const nav = el.sceneEl.systems.nav;
+    if (nav.navMesh && data.constrainToNavMesh && !this.data.fly) {
         if (velocity.lengthSq() < EPS) return;
 
         start.copy(el.object3D.position);
         end.copy(start).add(this.getMovementVector(delta));
 
-        const nav = el.sceneEl.systems.nav;
         this.navGroup = this.navGroup === null ? nav.getGroup(start) : this.navGroup;
         this.navNode = this.navNode || nav.getNode(start, this.navGroup);
         this.navNode = nav.clampStep(start, end, this.navGroup, this.navNode, clampedEnd);

--- a/src/aframe-mods/wasd-speed-controls.js
+++ b/src/aframe-mods/wasd-speed-controls.js
@@ -9,6 +9,10 @@ AFRAME.components['wasd-controls'].Component.prototype.init = function() {
     // Navigation
     this.navGroup = null;
     this.navNode = null;
+    this.navStart = new THREE.Vector3();
+    this.navEnd = new THREE.Vector3();
+    this.clampedEnd = new THREE.Vector3();
+
     // To keep track of the pressed keys.
     this.keys = {};
     this.easing = 1.1;
@@ -34,10 +38,6 @@ AFRAME.components['wasd-controls'].Component.prototype.tick = function(time, del
     const el = this.el;
     const velocity = this.velocity;
 
-    const start = new THREE.Vector3();
-    const end = new THREE.Vector3();
-    const clampedEnd = new THREE.Vector3();
-
     if (!velocity[data.adAxis] && !velocity[data.wsAxis] &&
         isEmptyObject(this.keys)) {
         return;
@@ -51,16 +51,16 @@ AFRAME.components['wasd-controls'].Component.prototype.tick = function(time, del
         return;
     }
     const nav = el.sceneEl.systems.nav;
-    if (nav.navMesh && data.constrainToNavMesh && !this.data.fly) {
+    if (nav.navMesh && data.constrainToNavMesh && !data.fly) {
         if (velocity.lengthSq() < EPS) return;
 
-        start.copy(el.object3D.position);
-        end.copy(start).add(this.getMovementVector(delta));
+        this.navStart.copy(el.object3D.position);
+        this.navEnd.copy(this.navStart).add(this.getMovementVector(delta));
 
-        this.navGroup = this.navGroup === null ? nav.getGroup(start) : this.navGroup;
-        this.navNode = this.navNode || nav.getNode(start, this.navGroup);
-        this.navNode = nav.clampStep(start, end, this.navGroup, this.navNode, clampedEnd);
-        el.object3D.position.copy(clampedEnd);
+        this.navGroup = this.navGroup === null ? nav.getGroup(this.navStart) : this.navGroup;
+        this.navNode = this.navNode || nav.getNode(this.navStart, this.navGroup);
+        this.navNode = nav.clampStep(this.navStart, this.navEnd, this.navGroup, this.navNode, this.clampedEnd);
+        el.object3D.position.copy(this.clampedEnd);
     } else {
         // Get movement vector and translate position.
         el.object3D.position.add(this.getMovementVector(delta));

--- a/src/aframe-mods/wasd-speed-controls.js
+++ b/src/aframe-mods/wasd-speed-controls.js
@@ -1,7 +1,73 @@
 /* global AFRAME */
 
+const bind = AFRAME.utils.bind;
 const CLAMP_VELOCITY = 0.00001;
 const MAX_DELTA = 0.2;
+const EPS = 10e-6;
+
+AFRAME.components['wasd-controls'].Component.prototype.init = function() {
+    // Navigation
+    this.navGroup = null;
+    this.navNode = null;
+    // To keep track of the pressed keys.
+    this.keys = {};
+    this.easing = 1.1;
+
+    this.velocity = new THREE.Vector3();
+
+    // Bind methods and add event listeners.
+    this.onBlur = bind(this.onBlur, this);
+    this.onContextMenu = bind(this.onContextMenu, this);
+    this.onFocus = bind(this.onFocus, this);
+    this.onKeyDown = bind(this.onKeyDown, this);
+    this.onKeyUp = bind(this.onKeyUp, this);
+    this.onVisibilityChange = bind(this.onVisibilityChange, this);
+    this.attachVisibilityEventListeners();
+};
+
+const wasdSchema = AFRAME.components['wasd-controls'].Component.prototype.schema;
+Object.assign(wasdSchema, {constrainToNavMesh: {default: false}});
+AFRAME.components['wasd-controls'].Component.prototype.schema = AFRAME.schema.process(wasdSchema);
+
+AFRAME.components['wasd-controls'].Component.prototype.tick = function(time, delta) {
+    const data = this.data;
+    const el = this.el;
+    const velocity = this.velocity;
+
+    const start = new THREE.Vector3();
+    const end = new THREE.Vector3();
+    const clampedEnd = new THREE.Vector3();
+
+    if (!velocity[data.adAxis] && !velocity[data.wsAxis] &&
+        isEmptyObject(this.keys)) {
+        return;
+    }
+
+    // Update velocity.
+    delta = delta / 1000;
+    this.updateVelocity(delta);
+
+    if (!velocity[data.adAxis] && !velocity[data.wsAxis]) {
+        return;
+    }
+
+    if (data.constrainToNavMesh) {
+        if (velocity.lengthSq() < EPS) return;
+
+        start.copy(el.object3D.position);
+        end.copy(start).add(this.getMovementVector(delta));
+
+        const nav = el.sceneEl.systems.nav;
+        this.navGroup = this.navGroup === null ? nav.getGroup(start) : this.navGroup;
+        this.navNode = this.navNode || nav.getNode(start, this.navGroup);
+        this.navNode = nav.clampStep(start, end, this.navGroup, this.navNode, clampedEnd);
+        el.object3D.position.copy(clampedEnd);
+    } else {
+        // Get movement vector and translate position.
+        el.object3D.position.add(this.getMovementVector(delta));
+    }
+};
+
 
 AFRAME.components['wasd-controls'].Component.prototype.updateVelocity = function(delta) {
     let adSign;
@@ -63,3 +129,16 @@ AFRAME.components['wasd-controls'].Component.prototype.updateVelocity = function
         }
     }
 };
+
+/**
+ * @param {object} keys
+ * @return {boolean}
+ */
+function isEmptyObject(keys) {
+    let key;
+    // eslint-disable-next-line guard-for-in
+    for (key in keys) {
+        return false;
+    }
+    return true;
+}

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -228,6 +228,6 @@ export class ARENAMqtt {
     isConnected(jsonMessage) {
         return this.mqttClient.isConnected();
     }
-};
+}
 
 


### PR DESCRIPTION
Resolves #163

Documentation on navmeshes: https://github.com/n5ro/aframe-extras/tree/master/src/pathfinding

Note: Because our cameras are offset @ `y=1.6`, navmeshes must be created with base 1.6 height.
