### PR TITLE
Remove component when it is set to null

### DIFF
--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -293,9 +293,14 @@ export class CreateUpdate {
      */
     static setComponentAttributes(entityEl, data, cName) {
         if (!AFRAME.components[cName]) return; // no component registered with this name
+        console.log('setComponentAttributes:', entityEl, data, cName)
         for (const [attribute, value] of Object.entries(data)) {
             if (AFRAME.components[cName].Component.prototype.schema[attribute]) {
-                entityEl.setAttribute(cName, attribute, value);
+                if (value === null) { // if null, remove attribute
+                    entityEl.removeAttribute(cName);
+                } else {
+                    entityEl.setAttribute(cName, attribute, value);
+                }                
                 delete data[attribute]; // we handled this attribute; remove it
             }
         }


### PR DESCRIPTION
Added support to remove a component by setting it to 'null'.

E.g., the flowing would remove the animation-mixer component:
{"object_id": "letter", "type": "object", "action": "update", "data": {"object_type": "gltf-model", "animation-mixer": null}, "action": "update"}' 

This could be used to handle #274. But maybe not the best way.