### PR TITLE
Add override src to material extras

### DIFF
--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -103,8 +103,6 @@
           "lon": 79.9428,
           "markerid": "0",
           "markertype": "apriltag_36h11",
-          "dynamic": false,
-          "buildable": false,
           "size": 150
         },
         "description": "A location marker (such as an AprilTag, a lightAnchor, or an UWB tag), used to anchor scenes in the real world. ",
@@ -142,16 +140,6 @@
             ],
             "title": "The marker type (apriltag_36h11, lightanchor, uwb)",
             "type": "string"
-          },
-          "dynamic":{
-            "type":"boolean",
-            "title":"Dynamic tag, not used for localization",
-            "default": false
-          },
-          "buildable":{
-            "type":"boolean",
-            "title":"Buildable tag, can be moved by scene author",
-            "default": false
           },
           "size": {
             "default": 150,
@@ -322,6 +310,42 @@
             "lookAtLandmark": true
         },
         "required": ["label"]
+      },
+      "material-extras": {
+        "default": {
+          "encoding": "sRGBEncoding",
+          "needsUpdate": false
+        },
+        "description": "Define extra material properties.",
+        "properties": {
+          "overrideSrc": {  
+            "type": "string",
+            "default": "",
+            "description": "Overrides the material in all meshes of an object (e.g. a basic shape or a GLTF); Use, for example, to change the texture of a GLTF."
+          },
+          "encoding": {
+            "default": "sRGBEncoding",
+            "enum": [
+              "LinearEncoding",
+              "sRGBEncoding",
+              "GammaEncoding",
+              "RGBEEncoding",
+              "LogLuvEncoding",
+              "RGBM7Encoding",
+              "RGBM16Encoding",
+              "RGBDEncoding",
+              "BasicDepthPacking",
+              "RGBADepthPacking"
+            ],
+            "type": "string"
+          },
+          "needsUpdate": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "title": "Material extras",
+        "type": "object"
       },
       "parent": {
         "description": "Parent's object_id. Child objects inherit attributes of their parent, for example scale and translation.",

--- a/build/schemas/definitions-geometries.json
+++ b/build/schemas/definitions-geometries.json
@@ -1,0 +1,181 @@
+{
+    "properties": {
+      "buffer": {
+        "default": "true",
+        "description": "Transform geometry into a BufferGeometry to reduce memory usage at the cost of being harder to manipulate (geometries only: box, circle, cone, ...).",
+        "title": "Buffer",
+        "type": "boolean"
+      },
+      "material": {
+        "description": "The material properties of the object’s surface.",
+        "properties": {
+          "alphaTest": {
+            "default": 0,
+            "description": "Alpha test threshold for transparency.",
+            "type": "number"
+          },
+          "blending": {
+            "default": "normal",
+            "description": "The blending mode for the material’s RGB and Alpha sent to the WebGLRenderer. Can be one of none, normal, additive, subtractive or multiply",
+            "enum": [
+              "none",
+              "normal",
+              "additive",
+              "subtractive",
+              "multiply"
+            ],
+            "type": "string"
+          },
+          "color": {
+            "default": "#7f7f7f",
+            "description": "Base diffuse color.",
+            "format": "color",
+            "title": "color",
+            "type": "string"
+          },
+          "colorWrite": {
+            "description": "Color write",
+            "type": "boolean"
+          },
+          "depthTest": {
+            "default": true,
+            "description": "Whether depth testing is enabled when rendering the material.",
+            "type": "boolean"
+          },
+          "dithering": {
+            "default": true,
+            "description": "Whether material is dithered with noise. Removes banding from gradients like ones produced by lighting.",
+            "type": "boolean"
+          },
+          "flatShading": {
+            "default": false,
+            "description": "Use THREE.FlatShading rather than THREE.StandardShading.",
+            "type": "boolean"
+          },
+          "npot": {
+            "default": false,
+            "description": "Use settings for non-power-of-two (NPOT) texture.",
+            "type": "boolean"
+          },
+          "offset": {
+            "default": {
+              "x": 1,
+              "y": 1
+            },
+            "description": "Texture offset to be used.",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y"
+            ],
+            "type": "object"
+          },
+          "opacity": {
+            "default": 1,
+            "description": "Extent of transparency. If the transparent property is not true, then the material will remain opaque and opacity will only affect color.",
+            "type": "number"
+          },
+          "render-order": {
+            "default": "0",
+            "description": "The render-order system takes a comma-delimited list of strings that name the render order layers. The render order layers will map to a number starting from 0 and counting up from there.",
+            "type": "string"
+          },
+          "repeat": {
+            "default": {
+              "x": 1,
+              "y": 1
+            },
+            "description": "Texture repeat to be used.",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "x",
+              "y"
+            ],
+            "type": "object"
+          },
+          "shader": {
+            "default": "standard",
+            "description": "Which material to use. Defaults to the standard material. Can be set to the flat material or to a registered custom shader material.",
+            "type": "string"
+          },
+          "side": {
+            "default": "front",
+            "description": "Which sides of the mesh to render. Can be one of front, back, or double.",
+            "enum": [
+              "front",
+              "back",
+              "double"
+            ],
+            "type": "string"
+          },
+          "src": {
+            "description": "URI, relative or full path of an image/video file. e.g. 'store/users/wiselab/images/360falls.mp4'",
+            "format": "uri",
+            "type": "string"
+          },
+          "transparent": {
+            "default": false,
+            "description": "Whether material is transparent. Transparent entities are rendered after non-transparent entities.",
+            "type": "boolean"
+          },
+          "vertexColors": {
+            "default": "none",
+            "description": "Whether to use vertex or face colors to shade the material. Can be one of none, vertex, or face.",
+            "enum": [
+              "none",
+              "vertex",
+              "face"
+            ],
+            "type": "string"
+          },
+          "visible": {
+            "default": true,
+            "description": "Whether material is visible. Raycasters will ignore invisible materials.",
+            "type": "boolean"
+          }
+        },
+        "title": "Material",
+        "type": "object"
+      },
+      "multisrc": {
+        "description": "Define multiple visual sources applied to an object.",
+        "properties": {
+          "srcs": {
+            "description": "A comma-delimited list if URIs, e.g. “side1.png, side2.png, side3.png, side4.png, side5.png, side6.png” (required).",
+            "type": "string"
+          },
+          "srcspath": {
+            "description": "URI, relative or full path of a directory containing srcs, e.g. “store/users/wiselab/images/dice/” (required).",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "srcspath",
+          "srcs"
+        ],
+        "title": "Multi Source",
+        "type": "object"
+      },
+      "skipCache": {
+        "default": "true",
+        "description": "Disable retrieving the shared geometry object from the cache. (geometries only: box, circle, cone, ...).",
+        "title": "Skip Cache",
+        "type": "boolean"
+      }
+    }
+  }

--- a/src/components/material-extras.js
+++ b/src/components/material-extras.js
@@ -14,7 +14,7 @@
  * The properties set here access directly [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * Implements a timeout scheme in lack of better understanding of the timing/events causing properties to not be available.
  * @module material-extras
- * @property {string} [overrideSrc=''] - Overrides the material in all meshes in an object (e.g. a GLTF); Used to change the texture of a GLTF}.
+ * @property {string} [overrideSrc=''] - Overrides the material in all meshes of an object (e.g. a basic shape or a GLTF).
  * @property {string} [encoding=sRGBEncoding] - The material encoding; One of 'LinearEncoding', 'sRGBEncoding', 'GammaEncoding', 'RGBEEncoding', 'LogLuvEncoding', 'RGBM7Encoding', 'RGBM16Encoding', 'RGBDEncoding', 'BasicDepthPacking', 'RGBADepthPacking'. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * @property {boolean} [needsUpdate=false] - Specifies that the material needs to be recompiled. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * @property {boolean} [colorWrite=true] - Whether to render the material's color. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.

--- a/src/components/material-extras.js
+++ b/src/components/material-extras.js
@@ -14,6 +14,7 @@
  * The properties set here access directly [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * Implements a timeout scheme in lack of better understanding of the timing/events causing properties to not be available.
  * @module material-extras
+ * @property {string} [overrideSrc=''] - Overrides the material in all meshes in an object (e.g. a GLTF); Used to change the texture of a GLTF}.
  * @property {string} [encoding=sRGBEncoding] - The material encoding; One of 'LinearEncoding', 'sRGBEncoding', 'GammaEncoding', 'RGBEEncoding', 'LogLuvEncoding', 'RGBM7Encoding', 'RGBM16Encoding', 'RGBDEncoding', 'BasicDepthPacking', 'RGBADepthPacking'. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * @property {boolean} [needsUpdate=false] - Specifies that the material needs to be recompiled. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
  * @property {boolean} [colorWrite=true] - Whether to render the material's color. See [Three.js material]{@link https://threejs.org/docs/#api/en/materials/Material}.
@@ -24,6 +25,7 @@
 AFRAME.registerComponent('material-extras', {
     dependencies: ['material'],
     schema: {
+        overrideSrc: {default: ''},
         encoding: {default: 'sRGBEncoding', oneOf: [
             'LinearEncoding', 'sRGBEncoding', 'GammaEncoding', 'RGBEEncoding', 'LogLuvEncoding',
             'RGBM7Encoding', 'RGBM16Encoding', 'RGBDEncoding', 'BasicDepthPacking', 'RGBADepthPacking']},
@@ -35,7 +37,12 @@ AFRAME.registerComponent('material-extras', {
     },
     retryTimeouts: [1000, 2000, 5000, 10000],
     init: function() {
+        this.loader = new THREE.TextureLoader();
+        this.needsUpdate = true;
+        if (this.data.overrideSrc.length > 0) this.loadTexture(this.data.overrideSrc);
         this.update();
+        this.el.addEventListener('model-loaded', () => this.update());
+        this.el.addEventListener('load', () => this.update());
     },
     update: function(oldData) {
         this.retryIndex = 0;
@@ -44,10 +51,14 @@ AFRAME.registerComponent('material-extras', {
         if (oldData) {
             transparentOccluder = oldData.transparentOccluder;
             if (oldData.renderOrder !== this.data.renderOrder ||
-                oldData.colorWrite !== this.data.colorWrite) {
-                this.data.needsUpdate = true;
+                oldData.colorWrite !== this.data.colorWrite ||
+                oldData.encoding !== this.data.encoding ||
+                oldData.overrideSrc !== this.data.overrideSrc) {
+                this.needsUpdate = true;
             }
-            if (this.data.encoding != oldData.transparentOccluder) this.data.needsUpdate = true;
+            if (oldData.overrideSrc !== this.data.overrideSrc) {
+                this.loadTexture(this.data.overrideSrc);
+            }
         }
 
         if (transparentOccluder !== this.data.transparentOccluder) {
@@ -59,29 +70,58 @@ AFRAME.registerComponent('material-extras', {
                 this.data.renderOrder = this.data.defaultRenderOrder; // default renderOrder used in the arena
                 this.data.colorWrite = true; // default colorWrite
             }
-            this.data.needsUpdate = true;
+            this.needsUpdate = true;
         }
         this.el.object3D.renderOrder=this.data.renderOrder;
 
         // do a retry scheme to apply material properties (waiting on events did not seem to work for all cases)
-        if (this.data.needsUpdate) this.updateMaterial();
+        if (this.needsUpdate) this.updateMaterial();
+    },
+    loadTexture(src) {
+        this.loader.load(
+            this.data.overrideSrc,
+            // onLoad callback
+            (texture) => {
+                this.texture = texture;
+                this.needsUpdate = true;
+                this.update();
+            },
+            // onProgress callback currently not supported
+            undefined,
+            // onError callback
+            (err) => console.error(`Error loading texture ${this.data.overrideSrc}: ${err}`));
     },
     updateMaterial: function() {
         const mesh = this.el.getObject3D('mesh');
-
         if (!mesh) {
-            console.error('could not find mesh!');
+            console.warn('Could not find mesh!');
             this.retryUpdateMaterial();
+            return;
         }
-
+        if (this.texture) {
+            mesh.traverse((node) => {
+                if (node.isMesh) {
+                    if (node.material.map) {
+                        node.material.map = this.texture;
+                        mesh.material.needsUpdate = true;
+                    }
+                }
+            });
+        }
         if (mesh.material) {
-            mesh.material.needsUpdate = this.data.needsUpdate;
             mesh.material.colorWrite = this.data.colorWrite;
             if (mesh.material.map) {
                 mesh.material.map.encoding = THREE[this.data.encoding];
                 this.data.needsUpdate = false;
-            } else this.retryUpdateMaterial();
-        } else this.retryUpdateMaterial();
+            } else {
+                this.retryUpdateMaterial();
+                return;
+            }
+            mesh.material.needsUpdate = true;
+        } else {
+            this.retryUpdateMaterial();
+            return;
+        }
     },
     retryUpdateMaterial() {
         if (this.retryIndex < this.retryTimeouts.length) {


### PR DESCRIPTION
 Overrides the material in all meshes of an object (e.g. a basic shape or a GLTF).

This should address #340 .