### PR TITLE
feat(avatar): Added ability to set multiple custom head models per scene

### DIFF
--- a/build/schemas/arena-scene-options.json
+++ b/build/schemas/arena-scene-options.json
@@ -359,7 +359,7 @@
                "title":"Head Model URLs",
                "type":"array",
                "minItems":1,
-               "maxItems":5,
+               "maxItems":10,
                "items":{
                   "type":"object",
                   "properties":{

--- a/build/schemas/arena-scene-options.json
+++ b/build/schemas/arena-scene-options.json
@@ -354,13 +354,28 @@
              },
              "sceneHeadModels":{
                "default":"",
-               "description":"Define default model(s) for the scene. You must scale and rotate your source GLTFs appropriately.",
+               "description":"Define the default head model(s) for the scene in a list. Users may still choose from the ARENA default list of head models as well.",
                "minLength":5,
                "title":"Head Model URLs",
                "type":"array",
+               "minItems":1,
                "maxItems":5,
                "items":{
-                  "type":"string"
+                  "type":"object",
+                  "properties":{
+                     "name":{
+                        "type":"string",
+                        "description":"A head model name for the selection GUI."
+                     },
+                     "url":{
+                        "type":"string",
+                        "description":"The head model GLTF URL. You must scale and rotate your source GLTFs appropriately."
+                     }
+                  },
+                  "required":[
+                     "name",
+                     "url"
+                  ]
                }
              },
              "jitsiHost":{

--- a/build/schemas/arena-scene-options.json
+++ b/build/schemas/arena-scene-options.json
@@ -352,12 +352,16 @@
                 "title":"Positional Audio Distance Model",
                 "type":"string"
              },
-             "sceneHeadModel":{
+             "sceneHeadModels":{
                "default":"",
-               "description":"Define a default model for the scene. You must scale and rotate your source GLTF appropriately.",
+               "description":"Define default model(s) for the scene. You must scale and rotate your source GLTFs appropriately.",
                "minLength":5,
-               "title":"Head Model URL",
-               "type":"string"
+               "title":"Head Model URLs",
+               "type":"array",
+               "maxItems":5,
+               "items":{
+                  "type":"string"
+               }
              },
              "jitsiHost":{
                 "default":"jitsi0.andrew.cmu.edu:8443",

--- a/src/arena.js
+++ b/src/arena.js
@@ -529,7 +529,7 @@ export class Arena {
                         sceneHeads.forEach((head) => {
                             const opt = document.createElement('option');
                             opt.value = head;
-                            opt.text = head;
+                            opt.text = `${head} (scene-options)`;
                             headModelPathSelect.add(opt, null);
                         });
                         if (headModelPathSelect.selectedIndex == 0) {

--- a/src/arena.js
+++ b/src/arena.js
@@ -524,19 +524,7 @@ export class Arena {
 
                     if (sceneOptions['sceneHeadModels']) {
                         // add scene custom scene heads to selection list
-                        const sceneHeads = sceneOptions['sceneHeadModels'];
-                        const headModelPathSelect = document.getElementById('headModelPathSelect');
-                        const defaultHeadsLen = headModelPathSelect.length; // static default heads list length
-                        sceneHeads.forEach((head) => {
-                            const opt = document.createElement('option');
-                            opt.value = head.url;
-                            opt.text = `${head.name} (scene-options)`;
-                            headModelPathSelect.add(opt, null);
-                        });
-                        // if default ARENA head used, replace with default scene head
-                        if (headModelPathSelect.selectedIndex <= 0) {
-                            headModelPathSelect.selectedIndex = defaultHeadsLen;
-                        }
+                        setupSceneHeadModels();
                     }
 
                     if (!sceneOptions['clickableOnlyEvents']) {
@@ -596,6 +584,33 @@ export class Arena {
                 this.sceneOptions = sceneOptions;
                 ARENA.events.emit(ARENAEventEmitter.events.SCENE_OPT_LOADED, true);
             });
+
+        /**
+         * Update the list of scene-specific heads the user can select from
+         */
+        function setupSceneHeadModels() {
+            const sceneHeads = sceneOptions['sceneHeadModels'];
+            const headModelPathSelect = document.getElementById('headModelPathSelect');
+            const defaultHeadsLen = headModelPathSelect.length; // static default heads list length
+            sceneHeads.forEach((head) => {
+                const opt = document.createElement('option');
+                opt.value = head.url;
+                opt.text = `${head.name} (scene-options)`;
+                headModelPathSelect.add(opt, null);
+            });
+            let headModelPathIdx = 0;
+            const sceneHist = JSON.parse(localStorage.getItem('sceneHistory')) || {};
+            const sceneHeadModelPathIdx = sceneHist[ARENA.namespacedScene]?.headModelPathIdx;
+            if (sceneHeadModelPathIdx != undefined) {
+                headModelPathIdx = sceneHeadModelPathIdx;
+            } else if (headModelPathSelect.selectedIndex == 0) {
+                // if default ARENA head used, replace with default scene head
+                headModelPathIdx = defaultHeadsLen;
+            } else if (localStorage.getItem('headModelPathIdx')) {
+                headModelPathIdx = localStorage.getItem('headModelPathIdx');
+            }
+            headModelPathSelect.selectedIndex = headModelPathIdx < headModelPathSelect.length ? headModelPathIdx : 0;
+        }
     };
 
     /**

--- a/src/arena.js
+++ b/src/arena.js
@@ -522,6 +522,17 @@ export class Arena {
                         sceneRoot.appendChild(navMesh);
                     }
 
+                    if (sceneOptions['sceneHeadModels']) {
+                        const sceneHeads = sceneOptions['sceneHeadModels'];
+                        const headModelPathSelect = document.getElementById('headModelPathSelect');
+                        sceneHeads.forEach((head) => {
+                            const opt = document.createElement('option');
+                            opt.value = head;
+                            opt.text = head;
+                            headModelPathSelect.add(opt, null);
+                        });
+                    }
+
                     if (!sceneOptions['clickableOnlyEvents']) {
                     // unusual case: clickableOnlyEvents = true by default, add warning...
                         ARENA.health.addError('scene-options.allObjectsClickable');

--- a/src/arena.js
+++ b/src/arena.js
@@ -523,17 +523,19 @@ export class Arena {
                     }
 
                     if (sceneOptions['sceneHeadModels']) {
+                        // add scene custom scene heads to selection list
                         const sceneHeads = sceneOptions['sceneHeadModels'];
                         const headModelPathSelect = document.getElementById('headModelPathSelect');
-                        const currentLen = headModelPathSelect.length;
+                        const defaultHeadsLen = headModelPathSelect.length;
                         sceneHeads.forEach((head) => {
                             const opt = document.createElement('option');
-                            opt.value = head;
-                            opt.text = `${head} (scene-options)`;
+                            opt.value = head.url;
+                            opt.text = `${head.name} (scene-options)`;
                             headModelPathSelect.add(opt, null);
                         });
+                        // if default ARENA head used, replace with default scene head
                         if (headModelPathSelect.selectedIndex == 0) {
-                            headModelPathSelect.selectedIndex = currentLen;
+                            headModelPathSelect.selectedIndex = defaultHeadsLen;
                         }
                     }
 

--- a/src/arena.js
+++ b/src/arena.js
@@ -526,7 +526,7 @@ export class Arena {
                         // add scene custom scene heads to selection list
                         const sceneHeads = sceneOptions['sceneHeadModels'];
                         const headModelPathSelect = document.getElementById('headModelPathSelect');
-                        const defaultHeadsLen = headModelPathSelect.length;
+                        const defaultHeadsLen = headModelPathSelect.length; // static default heads list length
                         sceneHeads.forEach((head) => {
                             const opt = document.createElement('option');
                             opt.value = head.url;
@@ -534,7 +534,7 @@ export class Arena {
                             headModelPathSelect.add(opt, null);
                         });
                         // if default ARENA head used, replace with default scene head
-                        if (headModelPathSelect.selectedIndex == 0) {
+                        if (headModelPathSelect.selectedIndex <= 0) {
                             headModelPathSelect.selectedIndex = defaultHeadsLen;
                         }
                     }

--- a/src/arena.js
+++ b/src/arena.js
@@ -525,12 +525,16 @@ export class Arena {
                     if (sceneOptions['sceneHeadModels']) {
                         const sceneHeads = sceneOptions['sceneHeadModels'];
                         const headModelPathSelect = document.getElementById('headModelPathSelect');
+                        const currentLen = headModelPathSelect.length;
                         sceneHeads.forEach((head) => {
                             const opt = document.createElement('option');
                             opt.value = head;
                             opt.text = head;
                             headModelPathSelect.add(opt, null);
                         });
+                        if (headModelPathSelect.selectedIndex == 0) {
+                            headModelPathSelect.selectedIndex = currentLen;
+                        }
                     }
 
                     if (!sceneOptions['clickableOnlyEvents']) {

--- a/src/components/arena-camera.js
+++ b/src/components/arena-camera.js
@@ -127,9 +127,7 @@ AFRAME.registerComponent('arena-camera', {
         }
 
         const headModelPathSelect = document.getElementById('headModelPathSelect');
-        if (ARENA.sceneHeadModel) {
-            msg.data.headModelPath = ARENA.sceneHeadModel;
-        } else if (headModelPathSelect) {
+        if (headModelPathSelect) {
             msg.data.headModelPath = headModelPathSelect.value;
         } else {
             msg.data.headModelPath = ARENA.defaults.headModelPath;

--- a/src/ui/av-setup.js
+++ b/src/ui/av-setup.js
@@ -56,10 +56,21 @@ window.setupAV = (callback) => {
         enterSceneBtn.addEventListener('click', () => {
             // Stash preferred devices
             localStorage.setItem('display_name', displayName.value);
-            localStorage.setItem('headModelPathIdx', headModelPathSelect.selectedIndex);
             localStorage.setItem('prefAudioInput', audioInSelect.value);
             localStorage.setItem('prefVideoInput', videoSelect.value);
             localStorage.setItem('prefAudioOutput', audioOutSelect.value);
+
+            // save preferred head model, globally, or per scene
+            if (ARENA.sceneHeadModels) {
+                const sceneHist = JSON.parse(localStorage.getItem('sceneHistory')) || {};
+                sceneHist[ARENA.namespacedScene] = {
+                    ...sceneHist[ARENA.namespacedScene],
+                    headModelPathIdx: headModelPathSelect.selectedIndex,
+                };
+                localStorage.setItem('sceneHistory', JSON.stringify(sceneHist));
+            } else {
+                localStorage.setItem('headModelPathIdx', headModelPathSelect.selectedIndex);
+            }
 
             // default is reverse of aframe's default - we want to "drag world to pan"
             const camera = document.getElementById('my-camera');
@@ -268,9 +279,18 @@ window.setupAV = (callback) => {
         }
     }
     setupPanel.classList.remove('d-none');
-    if (localStorage.getItem('headModelPathIdx')) {
-        headModelPathSelect.selectedIndex = localStorage.getItem('headModelPathIdx');
+    let headModelPathIdx = 0;
+    if (ARENA.sceneHeadModels) {
+        const sceneHist = JSON.parse(localStorage.getItem('sceneHistory')) || {};
+        const sceneHeadModelPathIdx = sceneHist[ARENA.namespacedScene]?.headModelPathIdx;
+        if (sceneHeadModelPathIdx) {
+            headModelPathIdx = sceneHeadModelPathIdx;
+        }
+    } else if (localStorage.getItem('headModelPathIdx')) {
+        headModelPathIdx = localStorage.getItem('headModelPathIdx');
     }
+    console.warn('headModelPathIdx', headModelPathIdx);
+    headModelPathSelect.selectedIndex = headModelPathIdx <= headModelPathSelect.length ? headModelPathIdx : 0;
     if (localStorage.getItem('display_name')) {
         displayName.value = localStorage.getItem('display_name');
         displayName.focus();

--- a/src/ui/av-setup.js
+++ b/src/ui/av-setup.js
@@ -271,7 +271,6 @@ window.setupAV = (callback) => {
     if (localStorage.getItem('headModelPathIdx')) {
         headModelPathSelect.selectedIndex = localStorage.getItem('headModelPathIdx');
     }
-    headModelPathSelect.disabled = ARENA.sceneHeadModel; // custom scene-options head in use
     if (localStorage.getItem('display_name')) {
         displayName.value = localStorage.getItem('display_name');
         displayName.focus();

--- a/src/ui/av-setup.js
+++ b/src/ui/av-setup.js
@@ -279,18 +279,9 @@ window.setupAV = (callback) => {
         }
     }
     setupPanel.classList.remove('d-none');
-    let headModelPathIdx = 0;
-    if (ARENA.sceneHeadModels) {
-        const sceneHist = JSON.parse(localStorage.getItem('sceneHistory')) || {};
-        const sceneHeadModelPathIdx = sceneHist[ARENA.namespacedScene]?.headModelPathIdx;
-        if (sceneHeadModelPathIdx) {
-            headModelPathIdx = sceneHeadModelPathIdx;
-        }
-    } else if (localStorage.getItem('headModelPathIdx')) {
-        headModelPathIdx = localStorage.getItem('headModelPathIdx');
+    if (localStorage.getItem('headModelPathIdx')) {
+        headModelPathSelect.selectedIndex = localStorage.getItem('headModelPathIdx');
     }
-    console.warn('headModelPathIdx', headModelPathIdx);
-    headModelPathSelect.selectedIndex = headModelPathIdx <= headModelPathSelect.length ? headModelPathIdx : 0;
     if (localStorage.getItem('display_name')) {
         displayName.value = localStorage.getItem('display_name');
         displayName.focus();


### PR DESCRIPTION
Uses localStorage `sceneHistory` to save choice and set in this way:
```json
    "scene-options": {
      "clickableOnlyEvents": true,
      "maxAVDist": 20,
      "privateScene": false,
      "disableVideoCulling": false,
      "sceneHeadModels": [
        {
          "name": "Head, Gray",
          "url": "/store/models/Head.gltf"
        },
        {
          "name": "Head 2",
          "url": "/store/models/Head2.glb"
        }
      ]
    }
```
![Screen Shot 2022-04-06 at 6 30 59 AM](https://user-images.githubusercontent.com/215994/161978735-48b34232-90e9-4bf3-bbcf-bcafea3213b2.png)
