### PR TITLE
fix: jitsi screenshare stream handling and receiver constraints

### DIFF
--- a/screenshare/index.js
+++ b/screenshare/index.js
@@ -17,14 +17,26 @@ let localTracks = [];
 const remoteTracks = {};
 
 /**
- *
+ * Cleanup and close the screenshare tab.
  */
 function unload() {
     for (let i = 0; i < localTracks.length; i++) {
         localTracks[i].dispose();
     }
-    conference.leave();
-    connection.disconnect();
+    if (conference) {
+        try {
+            conference.leave();
+        } catch (e) {
+            console.warn('Error leaving conference:', e);
+        }
+    }
+    if (connection) {
+        try {
+            connection.disconnect();
+        } catch (e) {
+            console.warn('Error disconnecting:', e);
+        }
+    }
     window.close();
 }
 
@@ -115,6 +127,7 @@ function onConnectionSuccess() {
         conference.sendEndpointStatsMessage(stats); // send to remote
     });
 
+    // Set display name and properties BEFORE joining so they propagate with the initial presence
     conference.setDisplayName(
         `${(+new Date()).toString(36)} ${window.params.screenSharePrefix}_${window.params.idTag}`
     );
@@ -171,8 +184,14 @@ JitsiMeetJS.mediaDevices.addEventListener(JitsiMeetJS.events.mediaDevices.DEVICE
 
 connection.connect();
 
+// createLocalTracks must run at top-level (during page load) because Chrome requires
+// getDisplayMedia to be triggered from a user gesture context. The page load itself
+// is considered a user gesture since the user clicked the screenshare button to open this tab.
+// The race condition where properties may not have propagated yet is handled by the
+// PARTICIPANT_PROPERTY_CHANGED handler in jitsi.js on the receiving side.
 JitsiMeetJS.createLocalTracks({ devices: ['desktop'] })
     .then(onLocalTracks)
     .catch((error) => {
-        throw error;
+        console.error('Failed to create local tracks:', error);
+        window.close();
     });

--- a/src/systems/core/jitsi.js
+++ b/src/systems/core/jitsi.js
@@ -308,6 +308,73 @@ AFRAME.registerSystem('arena-jitsi', {
     },
 
     /**
+     * Handle screenshare track setup for a participant. Called from both onRemoteTrack
+     * and PARTICIPANT_PROPERTY_CHANGED to handle the race condition where properties
+     * may arrive before or after the video track.
+     * @param {string} participantId Jitsi participant Id
+     * @param {string} videoId HTML video element Id
+     * @param {object} user JitsiParticipant object
+     */
+    handleScreenshareTrack(participantId, videoId, user) {
+        const { el } = this;
+        const { sceneEl } = el;
+
+        // Check if we already set up this screenshare (prevent double-setup)
+        if (this.screenShareDict[participantId]) return;
+
+        let dn = user.getProperty('screenshareDispName');
+        if (!dn) dn = user.getDisplayName();
+        if (!dn) dn = `No Name #${participantId}`;
+        const idTag = user.getProperty('screenshareidTag');
+        let objectIds = user.getProperty('screenshareObjIds');
+
+        if (!idTag || !objectIds) {
+            // Properties not available yet; PARTICIPANT_PROPERTY_CHANGED will retry
+            console.debug(`[screenshare] Properties not yet available for ${participantId}, deferring`);
+            return;
+        }
+
+        objectIds = objectIds.split(',');
+        sceneEl.emit(JITSI_EVENTS.SCREENSHARE, {
+            jid: participantId,
+            id: participantId,
+            dn,
+            sn: objectIds[0],
+            scene: ARENA.namespacedScene,
+            src: EVENT_SOURCES.JITSI,
+        });
+
+        // handle screen share video
+        for (let i = 0; i < objectIds.length; i++) {
+            if (objectIds[i]) {
+                const vidEl = document.getElementById(videoId);
+                if (!vidEl) continue;
+
+                // Wait for actual video data before binding texture.
+                // WebRTC streams start with MediaStreamTrack.muted=true until
+                // the media transport (JVB/P2P) establishes data flow.
+                // Binding an empty video causes a permanent black texture.
+                const tryUpdate = () => {
+                    if (vidEl.readyState >= 2) {
+                        this.updateScreenShareObject(objectIds[i], videoId, participantId);
+                        return true;
+                    }
+                    return false;
+                };
+
+                if (!tryUpdate()) {
+                    vidEl.addEventListener('loadeddata', () => tryUpdate(), { once: true });
+                    // Fallback poll in case loadeddata was missed
+                    const fallback = setInterval(() => {
+                        if (tryUpdate()) clearInterval(fallback);
+                    }, 500);
+                    setTimeout(() => clearInterval(fallback), 30000);
+                }
+            }
+        }
+    },
+
+    /**
      * Handles remote tracks
      * @param {object} track JitsiTrack object
      */
@@ -350,10 +417,15 @@ AFRAME.registerSystem('arena-jitsi', {
             // create HTML video elem to store video
             let vidEl = document.getElementById(videoId);
             if (!vidEl) {
-                vidEl = $(`<video autoplay='autoplay' id='${videoId}' playsinline/>`);
+                vidEl = $(`<video autoplay='autoplay' muted='muted' id='${videoId}' playsinline/>`);
                 $('a-assets').append(vidEl);
             }
-            track.attach(vidEl[0]);
+            track.attach($(`#${videoId}`)[0]);
+            // Explicitly play to ensure autoplay is triggered
+            const attachedVid = document.getElementById(videoId);
+            if (attachedVid) {
+                attachedVid.play().catch(() => {}); // Ignore autoplay errors, muted video will auto-play
+            }
 
             const user = this.conference.getParticipantById(participantId);
             let idTags = user.getProperty('arenaId');
@@ -361,43 +433,7 @@ AFRAME.registerSystem('arena-jitsi', {
             if (!idTags) return; // handle jitsi-only users that have not set the display name
 
             if (idTags.includes(data.screensharePrefix)) {
-                let dn = user.getProperty('screenshareDispName');
-                if (!dn) dn = user.getDisplayName();
-                if (!dn) dn = `No Name #${participantId}`;
-                const idTag = user.getProperty('screenshareidTag');
-                let objectIds = user.getProperty('screenshareObjIds');
-
-                if (idTag && objectIds) {
-                    objectIds = objectIds.split(',');
-                    sceneEl.emit(JITSI_EVENTS.SCREENSHARE, {
-                        jid: participantId,
-                        id: participantId,
-                        dn,
-                        sn: objectIds[0],
-                        scene: ARENA.namespacedScene,
-                        src: EVENT_SOURCES.JITSI,
-                    });
-
-                    // handle screen share video
-                    for (let i = 0; i < objectIds.length; i++) {
-                        if (objectIds[i]) {
-                            const video = $(`#${videoId}`);
-                            video.on('loadeddata', () => {
-                                this.updateScreenShareObject(objectIds[i], videoId, participantId);
-                            });
-                        }
-                    }
-                } else {
-                    // display as external user; possible spoofer
-                    sceneEl.emit(JITSI_EVENTS.USER_JOINED, {
-                        jid: participantId,
-                        id: participantId,
-                        dn,
-                        scene: ARENA.namespacedScene,
-                        src: EVENT_SOURCES.JITSI,
-                    });
-                    return;
-                }
+                this.handleScreenshareTrack(participantId, videoId, user);
             }
         }
 
@@ -530,7 +566,13 @@ AFRAME.registerSystem('arena-jitsi', {
         if (!this.remoteTracks[id]) return;
         const screenShareEl = this.screenShareDict[id];
         if (screenShareEl) {
-            screenShareEl.setAttribute('material', 'src', null);
+            // Only clear the material if it's still showing THIS user's video.
+            // Another user may have since started sharing on the same object.
+            const material = screenShareEl.getAttribute('material');
+            const srcId = material?.src?.id || (typeof material?.src === 'string' ? material.src.replace('#', '') : null);
+            if (!srcId || srcId === `video${id}`) {
+                screenShareEl.setAttribute('material', 'src', null);
+            }
             delete this.screenShareDict[id];
         }
         $(`#video${id}`).remove();
@@ -661,6 +703,14 @@ AFRAME.registerSystem('arena-jitsi', {
                             scene: this.conferenceName,
                             src: EVENT_SOURCES.JITSI,
                         });
+                    }
+                } else if (propertyKey === 'screenshareObjIds') {
+                    // Fallback: handle screenshare properties arriving after the video track.
+                    // This covers the race condition where onRemoteTrack fires before
+                    // participant properties have propagated via XMPP.
+                    if (this.remoteTracks[id] && this.remoteTracks[id][1]) {
+                        const videoId = `video${id}`;
+                        this.handleScreenshareTrack(id, videoId, user);
                     }
                 }
             }
@@ -1042,6 +1092,11 @@ AFRAME.registerSystem('arena-jitsi', {
             videoConstraints.onStageEndpoints = panoIds;
         }
         videoConstraints.constraints = constraints;
+        // Always forward all tracks (no limit) and keep the default constraints
+        videoConstraints.lastN = -1;
+        videoConstraints.defaultConstraints = {
+            maxHeight: ARENA?.videoDefaultResolutionConstraint || 180,
+        };
         this.conference.setReceiverConstraints(videoConstraints);
     },
 
@@ -1051,6 +1106,8 @@ AFRAME.registerSystem('arena-jitsi', {
         videoConstraints.defaultConstraints = {
             maxHeight: resolution,
         };
+        // Always forward all tracks (no limit)
+        videoConstraints.lastN = -1;
         this.conference.setReceiverConstraints(videoConstraints);
     },
 

--- a/src/systems/scene/screenshare.js
+++ b/src/systems/scene/screenshare.js
@@ -53,6 +53,6 @@ AFRAME.registerSystem('screenshareable', {
 
     get(object) {
         const objId = object.el.id.trim();
-        return this.screenshareable[objId];
+        return this.screenshareables[objId];
     },
 });


### PR DESCRIPTION
This addresses the JVB selective forwarding bug by explicitly setting lastN=-1 and maintaining default height constraints. Also fixes the screenshare property race condition and the screenshareable typo.