### PR TITLE
Videosphere fix, closes #734, #430

### DIFF
--- a/src/components/camera/arena-user.js
+++ b/src/components/camera/arena-user.js
@@ -571,7 +571,22 @@ AFRAME.registerComponent('arena-user', {
                 }
             }
             if (data.pano) {
-                this.evaluateRemoteResolution(1920);
+                if (this.distance < this.panoRadius) {
+                    // User is INSIDE the videosphere — always request full resolution
+                    this.evaluateRemoteResolution(1920);
+                } else if (arenaCameraComponent && arenaCameraComponent.isVideoFrustumCullingEnabled() && this.panoEl) {
+                    // User is OUTSIDE the videosphere — apply frustum culling
+                    const panoInView = arenaCameraComponent.viewIntersectsObject3D(this.panoEl.object3D);
+                    if (panoInView) {
+                        this.evaluateRemoteResolution(480);
+                    } else {
+                        this.muteVideo();
+                        this.evaluateRemoteResolution(0);
+                    }
+                } else {
+                    // User is OUTSIDE but frustum culling disabled — use reduced resolution
+                    this.evaluateRemoteResolution(480);
+                }
             } else if (inFieldOfView === false) {
                 this.muteVideo();
                 this.evaluateRemoteResolution(0);

--- a/src/components/camera/arena-user.js
+++ b/src/components/camera/arena-user.js
@@ -572,12 +572,18 @@ AFRAME.registerComponent('arena-user', {
             }
             if (data.pano) {
                 if (this.distance < this.panoRadius) {
-                    // User is INSIDE the videosphere — always request full resolution
+                    // User is INSIDE the videosphere — always request full resolution.
+                    // unmuteVideo() is required here: muteVideo() pauses the shared video<id>
+                    // element that the videosphere texture reads from, and without un-pausing on
+                    // the visible paths the sphere stays frozen/blank once it has ever been culled
+                    // (the #430 missing-unmute bug, exposed once the remote element actually plays).
+                    this.unmuteVideo();
                     this.evaluateRemoteResolution(1920);
                 } else if (arenaCameraComponent && arenaCameraComponent.isVideoFrustumCullingEnabled() && this.panoEl) {
                     // User is OUTSIDE the videosphere — apply frustum culling
                     const panoInView = arenaCameraComponent.viewIntersectsObject3D(this.panoEl.object3D);
                     if (panoInView) {
+                        this.unmuteVideo();
                         this.evaluateRemoteResolution(480);
                     } else {
                         this.muteVideo();
@@ -585,6 +591,7 @@ AFRAME.registerComponent('arena-user', {
                     }
                 } else {
                     // User is OUTSIDE but frustum culling disabled — use reduced resolution
+                    this.unmuteVideo();
                     this.evaluateRemoteResolution(480);
                 }
             } else if (inFieldOfView === false) {

--- a/src/components/object/jitsi-video.js
+++ b/src/components/object/jitsi-video.js
@@ -28,6 +28,7 @@ AFRAME.registerComponent('jitsi-video', {
         this.retryCount = 0;
         this.retryTimer = null;
         this.bridgeRequested = false;
+        this.localPanoRequested = false;
         ARENA.events.addEventListener(ARENA_EVENTS.JITSI_LOADED, this.ready.bind(this));
     },
 
@@ -39,10 +40,12 @@ AFRAME.registerComponent('jitsi-video', {
         this.onJitsiConnect = this.onJitsiConnect.bind(this);
         this.onJitsiNewUser = this.onJitsiNewUser.bind(this);
         this.onJitsiUserLeft = this.onJitsiUserLeft.bind(this);
+        this.onJitsiVideoMuteChanged = this.onJitsiVideoMuteChanged.bind(this);
 
         ARENA.events.addEventListener(JITSI_EVENTS.CONNECTED, this.onJitsiConnect);
         sceneEl.addEventListener(JITSI_EVENTS.USER_JOINED, this.onJitsiNewUser);
         sceneEl.addEventListener(JITSI_EVENTS.USER_LEFT, this.onJitsiUserLeft);
+        sceneEl.addEventListener(JITSI_EVENTS.VIDEO_MUTE_CHANGED, this.onJitsiVideoMuteChanged);
     },
 
     update(oldData) {
@@ -52,12 +55,14 @@ AFRAME.registerComponent('jitsi-video', {
         if (data.jitsiId !== oldData.jitsiId) {
             this.retryCount = 0;
             this.bridgeRequested = false;
+            this.localPanoRequested = false;
             this.updateVideo();
         }
 
         if (data.displayName !== oldData.displayName) {
             this.retryCount = 0;
             this.bridgeRequested = false;
+            this.localPanoRequested = false;
             this.updateVideo(); // user will need to enter the conference again
         }
     },
@@ -96,19 +101,68 @@ AFRAME.registerComponent('jitsi-video', {
         const user = e.detail;
         if (this.data.displayName === '') return;
 
+        // The local user owns this displayName: the local cornerVideo source is authoritative.
+        // Ignore any remote participant sharing the name -- in particular a reload ghost of our
+        // own previous session, which Jitsi keeps alive ~30-60s -- otherwise it overwrites jitsiId
+        // and flips the videosphere onto a dead remote stream (the sphere never binds #cornerVideo
+        // and stays blank until the ghost times out). onJitsiConnect handles the local binding.
+        if (ARENA.jitsi && ARENA.getDisplayName() === this.data.displayName) return;
+
         if (user.dn === this.data.displayName) {
             this.data.jitsiId = user.jid;
             this.retryCount = 0;
             this.bridgeRequested = false;
+            this.localPanoRequested = false;
             this.updateVideo();
         }
     },
 
     onJitsiUserLeft(e) {
         if (e.detail.jid === this.data.jitsiId) {
-            this.el.removeAttribute('material', 'src');
+            // Revert to the pre-video look so a lingering receiver doesn't freeze on the last
+            // frame when the source leaves/times out (mirrors the screenshare restore).
+            this.restoreObject();
+            // Drop the bridge-forwarding request we added for this source (keyed by jitsiId) so it
+            // doesn't linger as a stale high-res constraint on the bridge after the user leaves.
+            if (ARENA.jitsi?.screenShareSourceNames?.delete(`${this.data.jitsiId}-v0`)) {
+                ARENA.jitsi.applyReceiverConstraints(ARENA.jitsi.lastVideoConstraints);
+            }
             this.bridgeRequested = false;
         }
+    },
+
+    onJitsiVideoMuteChanged(e) {
+        if (e.detail.jid !== this.data.jitsiId) return;
+        if (e.detail.muted) {
+            // Source turned its camera off but stayed in the conference (no USER_LEFT fires), so
+            // revert to the pristine look instead of freezing a lingering receiver on the last frame.
+            this.restoreObject();
+        } else {
+            // Source turned its camera back on -- re-render its stream.
+            this.retryCount = 0;
+            this.updateVideo();
+        }
+    },
+
+    /**
+     * Revert the object to the pristine look captured before the video was applied, so lingering
+     * receivers don't stay frozen on the last decoded frame after the source leaves or its stream
+     * times out. The remote video<id> element is removed by the jitsi system on USER_LEFT, so the
+     * texture would otherwise keep showing its final frame.
+     */
+    restoreObject() {
+        const pano = this.el.tagName.toLowerCase() === 'a-videosphere';
+        // a-videosphere maps the `src` attribute to material.src; clear it so A-Frame's mapping
+        // doesn't immediately re-apply the (now removed) video element.
+        if (pano) this.el.removeAttribute('src');
+        const restore = this.restoreState;
+        if (restore && Object.keys(restore.material).length) {
+            // Restoring the whole material swaps out the frozen video texture map.
+            this.el.setAttribute('material', restore.material);
+        } else {
+            this.el.removeAttribute('material', 'src');
+        }
+        if (restore && !restore.hadExtras) this.el.removeAttribute('material-extras');
     },
 
     /**
@@ -138,6 +192,17 @@ AFRAME.registerComponent('jitsi-video', {
 
     setVideoSrc() {
         const pano = this.el.tagName.toLowerCase() === 'a-videosphere';
+        // Capture the object's pristine look ONCE, before we overlay the video, so a lingering
+        // receiver can be reverted to it (instead of frozen on the last frame) when the source
+        // leaves/times out. Mirrors the screenshare restore in jitsi.js onUserLeft. On an
+        // a-videosphere the `src` attribute maps to material.src, so the pristine src lives in
+        // the captured material object.
+        if (!this.restoreState) {
+            this.restoreState = {
+                material: { ...(this.el.getAttribute('material') || {}) },
+                hadExtras: this.el.hasAttribute('material-extras'),
+            };
+        }
         if (pano) {
             this.el.setAttribute('src', `#${this.videoID}`); // video only! (no audio)
             // ensure panoramic videospheres have max download resolution
@@ -175,10 +240,16 @@ AFRAME.registerComponent('jitsi-video', {
             return;
         }
 
+        let isLocal = false;
         if (ARENA.jitsi.getJitsiId() === data.jitsiId) {
+            isLocal = true;
             const pano = this.el.tagName.toLowerCase() === 'a-videosphere';
-            if (pano) {
-                // ensure panoramic videosphere local has max upload resolution, update local tracks
+            if (pano && !this.localPanoRequested) {
+                // Switch the local camera to high-res pano upload mode — ONCE. avConnect() rebuilds
+                // and re-mutes the local track each time it runs; calling it on every 500ms poll tick
+                // (below) churns cornerVideo so its readyState can never settle at 4 and the local
+                // videosphere never renders. Request it a single time, then just poll for readiness.
+                this.localPanoRequested = true;
                 ARENA.jitsi.pano = pano;
                 ARENA.jitsi.avConnect();
             }
@@ -198,17 +269,67 @@ AFRAME.registerComponent('jitsi-video', {
             return;
         }
 
-        // readyState >= 2 (HAVE_CURRENT_DATA) is sufficient for texture rendering;
-        // previously required exactly 4 (HAVE_ENOUGH_DATA) which could miss valid frames
-        if (jitsiVideo.readyState >= 2) {
+        if (jitsiVideo.readyState === 4) {
             // https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
             this.setVideoSrc();
             this.retryCount = 0; // success, reset for any future re-attempts
             return;
         }
 
-        // if not loaded yet, try to wait
-        this.retryWaitVideoLoad();
+        if (isLocal) {
+            // Local video: avConnect() is async with high-res getUserMedia (3840x1920 for pano);
+            // use simple unbounded poll matching original behavior — it always resolves
+            if (this.retryTimer) clearTimeout(this.retryTimer);
+            this.retryTimer = setTimeout(() => {
+                this.updateVideo();
+            }, 500);
+        } else {
+            // Remote video: use event listener for reliable, non-polling wait
+            this.waitForVideoReady(jitsiVideo);
+        }
+    },
+
+    /**
+     * Wait for the video element to be ready using event listeners rather than polling.
+     * This avoids both infinite polling loops and premature timeout issues.
+     * @param {HTMLVideoElement} videoEl The video element to wait on
+     */
+    waitForVideoReady(videoEl) {
+        // Unblock decoding before we rely on an event. An unmuted MediaStream <video> won't
+        // autoplay in Firefox, so it never reaches a playable state and `canplay` never fires.
+        // (jitsi.js onRemoteTrack now does this at attach too; kept here so the component is
+        // self-sufficient regardless of how the element was created.)
+        videoEl.muted = true; // eslint-disable-line no-param-reassign
+        if (videoEl.paused) {
+            videoEl.play().catch((e) => console.warn('jitsi-video: remote video play failed', e));
+        }
+
+        // If the bridge hasn't been asked to forward this source yet, request it now
+        // (don't wait for retries to exhaust first — this is the main #734 fix)
+        if (!this.bridgeRequested) {
+            this.requestBridgeConstraint();
+        }
+
+        // Level-check FIRST: `canplay` is edge-triggered, so if the element is already playable
+        // (readyState >= HAVE_FUTURE_DATA) the event has already fired and a freshly-attached
+        // listener would wait forever. This is the race that left Firefox receivers blank.
+        if (videoEl.readyState >= 3) {
+            this.setVideoSrc();
+            this.retryCount = 0;
+            return;
+        }
+
+        // Remove any previous listener to avoid duplicates
+        if (this._onCanPlay) {
+            videoEl.removeEventListener('canplay', this._onCanPlay);
+        }
+        this._onCanPlay = () => {
+            videoEl.removeEventListener('canplay', this._onCanPlay);
+            this._onCanPlay = null;
+            this.setVideoSrc();
+            this.retryCount = 0;
+        };
+        videoEl.addEventListener('canplay', this._onCanPlay);
     },
 
     retryWaitVideoLoad() {

--- a/src/components/object/jitsi-video.js
+++ b/src/components/object/jitsi-video.js
@@ -14,15 +14,20 @@ import { ARENA_EVENTS, JITSI_EVENTS } from '../../constants';
  * @module jitsi-video
  * @property {string} [jitsiId] - JitsiId of the video source; If defined will override displayName
  * @property {string} [displayName] - ARENA or Jitsi display name of the video source; Will be ignored if jitsiId is given. Editing this property requires reload
+ * @property {number} [maxRetries=20] - Maximum number of retries to wait for video to load
  *
  */
 AFRAME.registerComponent('jitsi-video', {
     schema: {
         jitsiId: { type: 'string', default: '' },
         displayName: { type: 'string', default: '' },
+        maxRetries: { type: 'number', default: 20 },
     },
 
     init() {
+        this.retryCount = 0;
+        this.retryTimer = null;
+        this.bridgeRequested = false;
         ARENA.events.addEventListener(ARENA_EVENTS.JITSI_LOADED, this.ready.bind(this));
     },
 
@@ -45,10 +50,14 @@ AFRAME.registerComponent('jitsi-video', {
         if (!data) return;
 
         if (data.jitsiId !== oldData.jitsiId) {
+            this.retryCount = 0;
+            this.bridgeRequested = false;
             this.updateVideo();
         }
 
         if (data.displayName !== oldData.displayName) {
+            this.retryCount = 0;
+            this.bridgeRequested = false;
             this.updateVideo(); // user will need to enter the conference again
         }
     },
@@ -89,6 +98,8 @@ AFRAME.registerComponent('jitsi-video', {
 
         if (user.dn === this.data.displayName) {
             this.data.jitsiId = user.jid;
+            this.retryCount = 0;
+            this.bridgeRequested = false;
             this.updateVideo();
         }
     },
@@ -96,7 +107,33 @@ AFRAME.registerComponent('jitsi-video', {
     onJitsiUserLeft(e) {
         if (e.detail.jid === this.data.jitsiId) {
             this.el.removeAttribute('material', 'src');
+            this.bridgeRequested = false;
         }
+    },
+
+    /**
+     * Request the Jitsi bridge to forward video for this jitsiId. Videosphere sources
+     * rendered on a-videosphere elements don't have their own arena-user component, so
+     * they are never included in the constraints built by evaluateRemoteResolution. With
+     * enableLayerSuspension active, the bridge won't forward frames for unrequested
+     * endpoints, causing the video element to stay blank (the root cause of #734).
+     */
+    requestBridgeConstraint() {
+        if (this.bridgeRequested) return;
+        if (!ARENA.jitsi?.conference) return;
+
+        const { data } = this;
+        const sourceName = `${data.jitsiId}-v0`;
+        const pano = this.el.tagName.toLowerCase() === 'a-videosphere';
+        const resolution = pano ? 1920 : 480;
+
+        // Add to screenshare source names so applyReceiverConstraints always includes it
+        ARENA.jitsi.screenShareSourceNames.add(sourceName);
+        // Re-apply current constraints with the new source included
+        ARENA.jitsi.applyReceiverConstraints(ARENA.jitsi.lastVideoConstraints);
+
+        this.bridgeRequested = true;
+        console.info(`jitsi-video: requested bridge constraint for ${sourceName} at ${resolution}p`);
     },
 
     setVideoSrc() {
@@ -112,6 +149,17 @@ AFRAME.registerComponent('jitsi-video', {
                     data.panoId = this.el.id;
                 }
             });
+
+            // Ensure the video element plays; autoplay alone can be blocked by the browser
+            // until a user gesture. Mute so autoplay is always permitted (audio rides a
+            // separate track through WebAudio/positional audio).
+            const vidEl = document.getElementById(this.videoID);
+            if (vidEl) {
+                vidEl.muted = true;
+                if (vidEl.paused) {
+                    vidEl.play().catch((e) => console.warn('jitsi-video: videosphere play failed', e));
+                }
+            }
         } else {
             this.el.setAttribute('material', 'src', `#${this.videoID}`); // video only! (no audio)
             this.el.setAttribute('material-extras', 'colorSpace', 'SRGBColorSpace');
@@ -150,9 +198,12 @@ AFRAME.registerComponent('jitsi-video', {
             return;
         }
 
-        if (jitsiVideo.readyState === 4) {
+        // readyState >= 2 (HAVE_CURRENT_DATA) is sufficient for texture rendering;
+        // previously required exactly 4 (HAVE_ENOUGH_DATA) which could miss valid frames
+        if (jitsiVideo.readyState >= 2) {
             // https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
             this.setVideoSrc();
+            this.retryCount = 0; // success, reset for any future re-attempts
             return;
         }
 
@@ -161,8 +212,38 @@ AFRAME.registerComponent('jitsi-video', {
     },
 
     retryWaitVideoLoad() {
-        setTimeout(async () => {
+        const { data } = this;
+
+        if (this.retryCount >= data.maxRetries) {
+            // On exhaustion, request the bridge to forward this source and try once more
+            if (!this.bridgeRequested) {
+                console.warn(
+                    `jitsi-video: retries exhausted for ${data.jitsiId}, ` +
+                        `requesting bridge constraint and trying once more`
+                );
+                this.requestBridgeConstraint();
+                this.retryCount = 0; // reset to allow a second round after bridge request
+                this.retryTimer = setTimeout(() => {
+                    this.updateVideo();
+                }, 1000);
+                return;
+            }
+            console.warn(
+                `jitsi-video: video load failed for ${data.jitsiId} after ${data.maxRetries} retries ` +
+                    `(even after bridge constraint request)`
+            );
+            return;
+        }
+
+        // Exponential backoff: 500ms, 1000ms, 2000ms, 4000ms cap
+        const delay = Math.min(500 * 2 ** this.retryCount, 4000);
+        this.retryCount++;
+
+        if (this.retryTimer) {
+            clearTimeout(this.retryTimer);
+        }
+        this.retryTimer = setTimeout(() => {
             this.updateVideo();
-        }, 500); // try again in a bit
+        }, delay);
     },
 });

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -35,6 +35,7 @@ export const JITSI_EVENTS = Object.freeze({
     STATS_LOCAL: 'onarenajitsistatslocal',
     STATS_REMOTE: 'onarenajitsistatsremote',
     STATUS: 'onarenajitsistatus',
+    VIDEO_MUTE_CHANGED: 'onarenajitsivideomutechanged',
     CONFERENCE_ERROR: 'onarenajitsierror',
 });
 

--- a/src/systems/core/jitsi.js
+++ b/src/systems/core/jitsi.js
@@ -387,6 +387,17 @@ AFRAME.registerSystem('arena-jitsi', {
             }
             track.attach(vidEl[0]);
 
+            // Autoplay of an unmuted MediaStream <video> is blocked by Firefox until a user
+            // gesture, so the element never decodes, `canplay`/`loadeddata` never fire, and the
+            // remote videosphere/avatar stays blank. Chrome's MediaStream autoplay is lenient and
+            // renders anyway -- which is why this only reproduced on Firefox receivers. Mute (this
+            // is the video-only track; audio rides the separate `audio<id>` element) and start
+            // playback immediately, mirroring the screenshare path below.
+            vidEl[0].muted = true;
+            if (vidEl[0].paused) {
+                vidEl[0].play().catch((e) => console.warn('jitsi-video: remote video play failed', e));
+            }
+
             const user = this.conference.getParticipantById(participantId);
             let idTags = user.getProperty('arenaId');
             if (!idTags) idTags = user.getDisplayName();
@@ -683,6 +694,18 @@ AFRAME.registerSystem('arena-jitsi', {
         this.conference.on(JitsiMeetJS.events.conference.TRACK_ADDED, this.onRemoteTrack);
         this.conference.on(JitsiMeetJS.events.conference.TRACK_REMOVED, (track) => {
             console.debug(`track removed!!!${track}`);
+        });
+        this.conference.on(JitsiMeetJS.events.conference.TRACK_MUTE_CHANGED, (track) => {
+            // A remote source can stop/start its camera without leaving the conference, so no
+            // USER_LEFT fires. Surface remote video mute state so objects bound to that source
+            // (e.g. a videosphere via jitsi-video) can revert/re-render instead of freezing on
+            // the last decoded frame.
+            if (track.isLocal() || track.getType() !== 'video') return;
+            sceneEl.emit(JITSI_EVENTS.VIDEO_MUTE_CHANGED, {
+                jid: track.getParticipantId(),
+                muted: track.isMuted(),
+                src: EVENT_SOURCES.JITSI,
+            });
         });
         this.conference.on(JitsiMeetJS.events.conference.CONFERENCE_JOINED, this.onConferenceJoined);
         this.conference.on(JitsiMeetJS.events.conference.USER_JOINED, this.onUserJoined);


### PR DESCRIPTION
fix(jitsi-video): reliable videosphere across browsers, sources, ghosts, and signal loss (https://github.com/arenaxr/arena-web-core/issues/734, https://github.com/arenaxr/arena-web-core/issues/430)
Make jitsi-video (videosphere + object) render reliably for both the sender
and receivers, and revert cleanly when the source goes away.

- Remote render (https://github.com/arenaxr/arena-web-core/issues/734): event-based load that creates remote video elements
  muted and play()s them at track attach, and pre-checks readyState before the
  canplay wait. Fixes a Firefox autoplay deadlock that Chrome's lenient
  MediaStream autoplay had masked (receivers rendered on Chrome, blank on
  Firefox), and requests the bridge to forward the videosphere source.
- Pano frustum culling (https://github.com/arenaxr/arena-web-core/issues/430): unmute on every visible path so a culled
  videosphere isn't left permanently paused on the shared video element.
- Local sender: request the hi-res pano avConnect() once instead of on every
  500ms poll, so cornerVideo can settle at readyState 4 and render.
- Display-name ownership: treat the local user as authoritative for their own
  displayName so a same-name reload ghost can't hijack the videosphere onto a
  dead remote stream.
- Loss of signal: restore the object's pristine material when the source
  leaves (USER_LEFT) or turns its camera off (new VIDEO_MUTE_CHANGED, from
  conference TRACK_MUTE_CHANGED) so lingering receivers don't freeze on the
  last frame; re-render on unmute.
- Drop the bridge forwarding request on USER_LEFT to avoid leaking a stale
  receiver constraint.