### PR TITLE
fix: guard RenderFusion MQTT publish/subscribe against disconnected c…

### DIFF
--- a/src/systems/renderfusion/signaling/mqtt-signaling.js
+++ b/src/systems/renderfusion/signaling/mqtt-signaling.js
@@ -20,6 +20,10 @@ export default class MQTTSignaling {
     }
 
     publish(topic, msg) {
+        if (!this.client || !this.client.isConnected()) {
+            console.warn('[render-client] MQTT not connected, skipping publish');
+            return;
+        }
         const message = new Paho.Message(msg);
         message.destinationName = topic;
         this.client.send(message);
@@ -56,6 +60,10 @@ export default class MQTTSignaling {
     }
 
     subscribe(topic) {
+        if (!this.client || !this.client.isConnected()) {
+            console.warn(`[render-client] MQTT not connected, skipping subscribe to: ${topic}`);
+            return;
+        }
         const logOptions = {
             onSuccess: () => {
                 if (this.dbg === true) console.debug(`Subscribe success to: ${topic}`);
@@ -65,6 +73,10 @@ export default class MQTTSignaling {
             },
         };
         this.client.subscribe(topic, logOptions);
+    }
+
+    isConnected() {
+        return this.client && this.client.isConnected();
     }
 
     mqttOnConnectionLost(responseObject) {

--- a/src/systems/renderfusion/webrtc-stats.js
+++ b/src/systems/renderfusion/webrtc-stats.js
@@ -102,7 +102,9 @@ export default class WebRTCStatsLogger {
                 info(`E2E Latency: ${stat.latency} ms`);
             }
 
-            this.signaler.sendStats(stat); // TODO (elu2): causing some disconnects for renderfusion when heartbeats not high enough
+            if (this.signaler.isConnected()) {
+                this.signaler.sendStats(stat); // TODO (elu2): causing some disconnects for renderfusion when heartbeats not high enough
+            }
         });
 
         this.lastReport = report;


### PR DESCRIPTION
…lient

When the WebRTC data channel closes (e.g., network timeout, Unity server disconnect), handleCloudDisconnect() calls connectToCloud() → sendConnectACK() → publish(), which throws 'AMQJSO011E Invalid state not connected' on the Paho MQTT client.

Additionally, the WebRTC stats polling loop continues calling sendStats() → publish() after disconnect, amplifying the error.

Guard all publish() and subscribe() calls with isConnected() checks so they log a warning instead of throwing an uncaught exception. Expose isConnected() on MQTTSignaling for external callers.